### PR TITLE
Build static libs

### DIFF
--- a/.github/workflows/build_static_libs.yml
+++ b/.github/workflows/build_static_libs.yml
@@ -51,19 +51,28 @@ jobs:
           # vcpkgJsonGlob: '**/vcpkg.json'
           # runVcpkgInstall: true
 
-      - name: package libs
+      - name: build & package libs
         run: >-
-          ./vcpkg export rocksdb
+          ./vcpkg export 
+            rocksdb
             zstd
             zlib
             snappy
             lz4
-            bzip2 
+            bzip2
+            --zip
             --triplet=${{ matrix.triplet }}
+            --output=rocksdb-${{ matrix.triplet }}
+            --output-dir=$HOME
+
+      - name: upload packaged libs
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+#          name: build-report-${{ runner.os }}${{ github.action }}
+          path: ~/rocksdb-${{ matrix.triplet }}.zip
+          #if-no-files-found: ignore
 
       - name: invalidate vcpkg cache
         run: echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
         if: ${{ failure() || cancelled() }}
-
-
-      # TODO rename & upload packaged libs

--- a/.github/workflows/build_static_libs.yml
+++ b/.github/workflows/build_static_libs.yml
@@ -1,0 +1,69 @@
+name: Build static libs
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+env:
+  VCPKG_DISABLE_METRICS: 1
+
+jobs:
+  export-rocksdb:
+
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            triplet: x64-osx
+          - os: ubuntu-latest
+            triplet: x64-linux
+          - os: windows-latest
+            triplet: x64-mingw-static
+          - os: windows-latest
+            triplet: x64-windows-static
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+
+      #- name: install CMake
+      #  uses: lukka/get-cmake@latest
+
+      #- name: cache vcpkg
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: ~/vcpkg
+      #    key: vcpkg-${{ runner.os }}
+
+      - name: checkout vcpkg
+        uses: actions/checkout@v3
+        with:
+          ref: 2023.01.09
+          path: ~/vcpkg
+          fetch-depth: 1
+
+      - name: setup vcpkg
+        uses: lukka/run-vcpkg@v10
+        with:
+          vcpkgDirectory: ~/vcpkg
+          # vcpkgJsonGlob: '**/vcpkg.json'
+          # runVcpkgInstall: true
+
+      - name: package libs
+        run: >-
+          ./vcpkg export rocksdb
+            zstd
+            zlib
+            snappy
+            lz4
+            bzip2 
+            --triplet=${{ matrix.triplet }}
+
+      - name: invalidate vcpkg cache
+        run: echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
+        if: ${{ failure() || cancelled() }}
+
+
+      # TODO rename & upload packaged libs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
+          - os: macos-latest
             task: macosX64Test
           - os: ubuntu-latest
             task: linuxX64Test


### PR DESCRIPTION
Build the static libs for each environment.

This is required because Linux apt-get installs an old version of RocksDB (v6), so does Homebrew on macOS. This might also help with #2 

Once the static libs can be compiled and retrieved, I will try embedding them into the library, then I can be sure that KotR can be used anywhere.